### PR TITLE
Update react-test-renderer version to 18.3.1 and add react override i…

### DIFF
--- a/expo-app/package.json
+++ b/expo-app/package.json
@@ -60,13 +60,16 @@
     "@types/react-test-renderer": "^19.1.0",
     "jest": "^29.2.1",
     "jest-expo": "~54.0.0",
-    "react-test-renderer": "19.1.0",
+    "react-test-renderer": "18.3.1",
     "typescript": "~5.9.2"
   },
   "private": true,
   "overrides": {
     "@firebase/auth": {
       "@react-native-async-storage/async-storage": "$@react-native-async-storage/async-storage"
+    },
+    "react-test-renderer": {
+      "react": "$react"
     }
   }
 }


### PR DESCRIPTION
…n package.json for compatibility.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR downgrades `react-test-renderer` from version 19.1.0 to 18.3.1 and adds a package override to ensure `react-test-renderer` uses the same React version as the main project, resolving version compatibility issues between React and its test renderer.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `expo-app/package.json` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->